### PR TITLE
TbNavBar positioning error

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -1985,10 +1985,10 @@ EOD;
 		$htmlOptions = self::addClassName('navbar', $htmlOptions);
 		$position = self::popOption('position', $htmlOptions);
 		$static = self::popOption('static', $htmlOptions, false);
-		if (isset($position) && in_array($position, self::$positions))
+		if ($static) // navbar cannot be both fixed and static
+			$htmlOptions = self::addClassName('navbar-static-top', $htmlOptions);		
+		else if (isset($position) && in_array($position, self::$positions)) 
 			$htmlOptions = self::addClassName('navbar-fixed-' . $position, $htmlOptions);
-		else if ($static) // navbar cannot be both fixed and static
-			$htmlOptions = self::addClassName('navbar-static-top', $htmlOptions);
 		$style = self::popOption('style', $htmlOptions);
 		if (isset($style) && in_array($style, self::$navbarStyles))
 			$htmlOptions = self::addClassName('navbar-' . $style, $htmlOptions);


### PR DESCRIPTION
I believe the order of parameter checking in order to decide if the navbar should be static or not is wrong!

Right now the code:
- First checks the position of the bar (POSITION_TOP or POSITION_BOTTOM) 
- and then checks to see if the bar should be static.

Since the position is always either POSITION_TOP or POSITION_BOTTOM then the bar will always appear as fixed.

In this pull request, the order of checks is changed.

so you can use something like:

``` php
<?php $this->widget('bootstrap.widgets.TbNavbar',array(
    'collapse'=>false,
    'htmlOptions' => array(
        'static' => true,
    ),
    ...
```

in order to have a navigation bar appear as static.
