### PR TITLE
TbHtml::normalizeInputOptions() must be static protected method.

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -2114,7 +2114,7 @@ EOD;
      * @param array $options the options.
      * @return array the normalized options.
      */
-    protected function normalizeInputOptions($options)
+    protected static function normalizeInputOptions($options)
     {
         $size = self::popOption('size', $options);
         if (!self::addSpanClass($options))


### PR DESCRIPTION
Code which uses it at the moment issues the following PHP error:

```
Non-static method TbHtml::normalizeInputOptions() should not be called statically 
```
