### PR TITLE
added ability to wrap carousel image inside link

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -3909,6 +3909,9 @@ EOD;
         $overlayOptions = self::addClassName('carousel-caption', $overlayOptions);
         $labelOptions = self::popOption('labelOptions', $htmlOptions, array());
         $captionOptions = self::popOption('captionOptions', $htmlOptions, array());
+        $url = self::popOption('url', $htmlOptions);
+        if ($url)
+            $content = CHtml::link($content, $url);
         $output = self::openTag('div', $htmlOptions);
         $output .= $content;
         if (isset($label) || isset($caption))


### PR DESCRIPTION
This makes carousel images clickable (an example is you have a banner called "check out our new products!" which once clicked takes you to the "new products" page).
