### PR TITLE
don't render an empty element if user has no flashes

### DIFF
--- a/widgets/TbAlert.php
+++ b/widgets/TbAlert.php
@@ -73,6 +73,8 @@ class TbAlert extends CWidget
 	{
 		/* @var $user CWebUser */
 		$user = Yii::app()->getUser();
+		if (count($user->getFlashes(false)) == 0)
+			return;
 		echo TbHtml::openTag('div', $this->htmlOptions);
 		foreach ($this->alerts as $style => $alert)
 		{


### PR DESCRIPTION
The TbAlert widget renders the container element even when there are no flashes to display. This fixes it.
