### PR TITLE
Add icon color support for buttons

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -2447,9 +2447,9 @@ EOD;
             $htmlOptions['data-toggle'] = 'button';
         $items = strpos($type, 'input') === false ? self::popOption('items', $htmlOptions, array()) : array();
         $icon = self::popOption('icon', $htmlOptions);
-        $iconColor = self::popOption('iconColor', $htmlOptions, self::ICON_COLOR_DEFAULT);
+        $iconOptions = self::popOption('iconOptions', $htmlOptions, array());
         if (!empty($icon) && strpos($type, 'input') === false) // inputs cannot have icons
-        $label = self::icon($icon, array('color'=>$iconColor)) . '&nbsp;' . $label;
+        $label = self::icon($icon, $iconOptions) . '&nbsp;' . $label;
         $dropdownOptions = $htmlOptions;
         self::removeOptions($htmlOptions, array('groupOptions', 'menuOptions', 'dropup'));
         self::addSpanClass($htmlOptions); // must be called here as CHtml renders buttons


### PR DESCRIPTION
Pull request #52 only added icon color support when calling TbHtml::icon() directly. This one adds an "iconColor" option for buttons which gets passed on to TbHtml::icon() as "color".

If icon() gets more functionality in the future it might be a better idea to pass an iconOptions array directly to icon() instead of the current approach.
