### PR TITLE
Attribute 'uncheckValue' for hidden inputs equals to false

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -1619,7 +1619,7 @@ EOD;
         $name = self::popOption('name', $htmlOptions);
         $unCheck = self::popOption('uncheckValue', $htmlOptions, '');
         $hiddenOptions = isset($htmlOptions['id']) ? array('id' => CHtml::ID_PREFIX . $htmlOptions['id']) : array('id' => false);
-        $hidden = $unCheck !== false ? CHtml::hiddenField($name, $unCheck, $hiddenOptions) : '';
+        $hidden = !empty($unCheck) ? CHtml::hiddenField($name, $unCheck, $hiddenOptions) : '';
         return $hidden . self::radioButtonList($name, $selection, $data, $htmlOptions);
     }
 
@@ -1654,7 +1654,7 @@ EOD;
         $name = self::popOption('name', $htmlOptions);
         $unCheck = self::popOption('uncheckValue', $htmlOptions, '');
         $hiddenOptions = isset($htmlOptions['id']) ? array('id' => CHtml::ID_PREFIX . $htmlOptions['id']) : array('id' => false);
-        $hidden = $unCheck !== false ? CHtml::hiddenField($name, $unCheck, $hiddenOptions) : '';
+        $hidden = !empty($unCheck) ? CHtml::hiddenField($name, $unCheck, $hiddenOptions) : '';
         return $hidden . self::checkBoxList($name, $selection, $data, $htmlOptions);
     }
 


### PR DESCRIPTION
The same way as other attributes are set to false to be disabled.
The default value is set explicitly to empty string, so it is never `null`
