### PR TITLE
Resolve checkbox/radiobutton labels same way as all other input labels

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -1981,7 +1981,7 @@ EOD;
 
         if (in_array($type, array(self::INPUT_TYPE_CHECKBOX, self::INPUT_TYPE_RADIOBUTTON)))
         {
-            $htmlOptions = self::defaultOption('label', $model->getAttributeLabel($attribute), $htmlOptions);
+            $htmlOptions = self::defaultOption('label', CHtml::activeLabelEx($model, $attribute, $labelOptions), $htmlOptions);
             $htmlOptions['labelOptions'] = $labelOptions;
             $label = false;
         }


### PR DESCRIPTION
<?php echo $form->checkBoxControlGroup($model, "[$k]default"); ?>

Using this above code (where $k is 0) the label for the check box would become "[0]default" when it should be "Default".

There seems to be no clear conventions regarding the use of "self" vs. "CHtml" so I went with the latter.
