### PR TITLE
Don't randomize script identifiers (may brake certain client script implementations)

### DIFF
--- a/components/TbApi.php
+++ b/components/TbApi.php
@@ -27,6 +27,11 @@ class TbApi extends CApplicationComponent
 	const PLUGIN_TOOLTIP = 'tooltip';
 	const PLUGIN_TRANSITION = 'transition';
 	const PLUGIN_TYPEAHEAD = 'typeahead';
+	
+	/**
+	 * @var int static counter, used for determining script identifiers
+	 */
+	public static $counter = 0;
 
 	/**
 	 * @var bool whether we should copy the asset file or directory even if it is already published before.
@@ -174,7 +179,8 @@ class TbApi extends CApplicationComponent
 	{
 		$options = !empty($options) ? CJavaScript::encode($options) : '';
 		$script = "jQuery('{$selector}').{$name}({$options});";
-		Yii::app()->clientScript->registerScript($this->getUniqueScriptId(), $script, $position);
+		$id = __CLASS__.'#Plugin'.self::$counter++;
+		Yii::app()->clientScript->registerScript($id, $script, $position);
 	}
 
 	/**
@@ -197,7 +203,8 @@ class TbApi extends CApplicationComponent
 
 			$script .= "jQuery('{$selector}').on('{$name}', {$handler});";
 		}
-		Yii::app()->clientScript->registerScript($this->getUniqueScriptId(), $script, $position);
+		$id = __CLASS__.'#Events'.self::$counter++;
+		Yii::app()->clientScript->registerScript($id, $script, $position);
 	}
 
 	/**
@@ -216,12 +223,4 @@ class TbApi extends CApplicationComponent
 		}
 	}
 
-	/**
-	 * Generates a "somewhat" random id string.
-	 * @return string the id.
-	 */
-	protected function getUniqueScriptId()
-	{
-		return uniqid(__CLASS__ . '#', true);
-	}
 }


### PR DESCRIPTION
TbApi needlessly generates new unique IDs for all scripts it registers, which may brake client script implementations (well, mine at least) that check if the scripts at a certain position has changed since the last request. Since there's no point in using different IDs on every request I changed the logic to use a static counter (like CHtml does).
