### PR TITLE
add type="button" to all close buttons

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -3743,6 +3743,7 @@ EOD;
     {
         $htmlOptions = self::addClassName('close', $htmlOptions);
         $htmlOptions = self::defaultOption('data-dismiss', 'alert', $htmlOptions);
+        $htmlOptions = self::defaultOption('type', 'button', $htmlOptions);
         return self::tag($tag, $htmlOptions, $label);
     }
 


### PR DESCRIPTION
See https://github.com/twitter/bootstrap/issues/3465 and http://twitter.github.io/bootstrap/javascript.html#modals

This fixes an issue where pressing Enter while focusing on a text-field in a modal dialog would simply close the modal instead of submit the form as one would expect.

Since type="button" is present on all close buttons in the official docs I figured it should be fixed in this method instead of just in TbModal.
