### PR TITLE
added "inlineErrors" option to TbActiveForm (thanks @dolpox)

### DIFF
--- a/widgets/TbActiveForm.php
+++ b/widgets/TbActiveForm.php
@@ -33,9 +33,9 @@ class TbActiveForm extends CActiveForm
     public $successMessageCssClass = 'success';
     
     /**
-     * @var boolean whether to display inline errors. Defaults to true.
+     * @var boolean whether to hide inline errors. Defaults to false.
      */
-    public $inlineErrors = true;
+    public $hideInlineErrors = false;
 
     /**
      * Initializes the widget.
@@ -688,7 +688,7 @@ class TbActiveForm extends CActiveForm
 		// kind of a hack for ajax forms but this works for now.
 		if (!empty($error) && strpos($error, 'display:none') === false)
 			$options['color'] = TbHtml::INPUT_COLOR_ERROR;
-		if ($this->inlineErrors)
+		if (!$this->hideInlineErrors)
 			$options['error'] = $error;
 		$helpOptions = TbHtml::popOption('helpOptions', $options, array());
 		$helpOptions['type'] = $this->helpType;


### PR DESCRIPTION
I needed #66 for a project but @dolpox hasn't fixed the issues with his PR in two weeks so I decided to do it. What has changed here is that the option defaults to true (boolean true, not a string) and tab/spaces usage matches the surrounding code (this file uses both tabs and spaces, which is another issue that should be dealt with).
