### PR TITLE
Render close tags for the carousel indicator elements

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -3985,7 +3985,7 @@ EOD;
             $itemOptions = array('data-target' => $target, 'data-slide-to' => $i);
             if ($i === 0)
                 $itemOptions['class'] = 'active';
-            $output .= self::tag('li', $itemOptions);
+            $output .= self::tag('li', $itemOptions, '', true);
         }
         $output .= '</ol>';
         return $output;


### PR DESCRIPTION
Because <li /> isn't valid HTML.
