### PR TITLE
Render gap between buttons in TbHtml::formActions

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -2338,7 +2338,7 @@ EOD;
     {
         self::addCssClass('form-actions', $htmlOptions);
         if (is_array($actions)) {
-            $actions = implode('', $actions);
+            $actions = implode(' ', $actions);
         }
         return self::tag('div', $htmlOptions, $actions);
     }


### PR DESCRIPTION
When use:

<?php echo TbHtml::formActions(array(
TbHtml::submitButton(Yii::t('app', 'Login'), array('color' => TbHtml::BUTTON_COLOR_PRIMARY)),
TbHtml::resetButton(Yii::t('app', 'Reset')),
)); ?>

both buttons are rendered without gap between them, when there is a space (in implode), is drawn with a slight gap as:

<- div class="form-actions">
<?php echo TbHtml::submitButton(Yii::t('app', 'Search'),  array('color' => TbHtml::BUTTON_COLOR_PRIMARY,));?>
<?php echo TbHtml::resetButton(Yii::t('app', 'Reset')); ?>
<- /div>

With TbHtml::formActions:
![captura de pantalla 2013-07-31 a la s 12 45 27](https://f.cloud.github.com/assets/2007152/887699/aa41bb1a-fa00-11e2-929e-705030ae7014.png)
With <-div class="form-actions">...<-/div>
![captura de pantalla 2013-07-31 a la s 12 45 15](https://f.cloud.github.com/assets/2007152/887698/aa15e5c6-fa00-11e2-8c60-1f0a9615c5bf.png)
