### PR TITLE
Fix TbNav::isItemActive() when inside a module

### DIFF
--- a/widgets/TbNav.php
+++ b/widgets/TbNav.php
@@ -158,7 +158,15 @@ class TbNav extends CWidget
      */
     protected function isItemActive($item, $route)
     {
-        if (isset($item['url']) && is_array($item['url']) && !strcasecmp(trim($item['url'][0], '/'), $route)) {
+        $itemRoute = trim($item['url'][0], '/');
+        
+        // Prepend the current module to the item route if it is not present
+        if (Yii::app()->controller->module !== null && substr_count($itemRoute, '/') === 1) {
+            $moduleId = Yii::app()->controller->module->id;
+            $itemRoute = implode('/', array($moduleId, $itemRoute));
+        }
+        
+        if (isset($item['url']) && is_array($item['url']) && !strcasecmp($itemRoute, $route)) {
             unset($item['url']['#']);
             if (count($item['url']) > 1) {
                 foreach (array_splice($item['url'], 1) as $name => $value) {


### PR DESCRIPTION
Yii::app()->route always contains the module ID when inside a module, thus we need to prepend it to the item's route if it is not present (since it can be omitted, just like the controller can be omitted for same-controller actions). With the old code, no menu item would ever become active since the strcasecmp() would never return zero.

I'm not sure if this is the cleanest way to tackle this issue, though it works just fine.
