### PR TITLE
Fix rendering of dropdown lists since 030103997c3721bb378ee280a8af8cc42060b9b4

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -870,9 +870,9 @@ class TbHtml extends CHtml // required in order to access the protected methods 
      */
     public static function dropDownList($name, $select, $data, $htmlOptions = array())
     {
-        $displaySize = TbArray::popValue('displaySize', $htmlOptions, 4);
+        $displaySize = TbArray::popValue('displaySize', $htmlOptions, false);
         $htmlOptions = self::normalizeInputOptions($htmlOptions);
-        if (!empty($displaySize)) {
+        if ($displaySize) {
             $htmlOptions['size'] = $displaySize;
         }
         return parent::dropDownList($name, $select, $data, $htmlOptions);
@@ -1642,9 +1642,9 @@ EOD;
      */
     public static function activeDropDownList($model, $attribute, $data, $htmlOptions = array())
     {
-        $displaySize = TbArray::popValue('displaySize', $htmlOptions, 4);
+        $displaySize = TbArray::popValue('displaySize', $htmlOptions, false);
         $htmlOptions = self::normalizeInputOptions($htmlOptions);
-        if (!empty($displaySize)) {
+        if ($displaySize) {
             $htmlOptions['size'] = $displaySize;
         }
         return parent::activeDropDownList($model, $attribute, $data, $htmlOptions);


### PR DESCRIPTION
This changes the default value of "displaySize" to false, otherwise a dropdown list will behave like a "listBox" by default, which I doubt is the desired behavior.
