### PR TITLE
Fix broken logic in TbHtml::addCssClass()

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -4195,7 +4195,7 @@ EOD;
     {
         // Always operate on arrays
         if (is_string($className)) {
-            $className = array($className);
+            $className = explode(' ', $className);
         }
         if (isset($htmlOptions['class'])) {
             $classes = array_filter(explode(' ', $htmlOptions['class']));


### PR DESCRIPTION
The pattern used in preg_match() doesn't work as intended since e.g. a
dash is treated as a word boundary. With this change the class string
is always operated on as an array and also removes the possibility of
accidentally ending up with duplicate class names.
