### PR TITLE
always normalize the URL, otherwise the "href" attribute is not rendered

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -2370,9 +2370,7 @@ EOD;
      */
     public static function link($text, $url = '#', $htmlOptions = array())
     {
-        if ($url !== false) {
-            $htmlOptions['href'] = parent::normalizeUrl($url);
-        }
+        $htmlOptions['href'] = parent::normalizeUrl($url);
         self::clientChange('click', $htmlOptions);
         return self::tag('a', $htmlOptions, $text);
     }


### PR DESCRIPTION
which makes browsers treat the link as text (which causes the wrong
mouse pointer to be used)
