### PR TITLE
fix error in navList with TbHtml::menuDivider()

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -2969,7 +2969,7 @@ EOD;
     public static function navList($items, $htmlOptions = array())
     {
         foreach ($items as $i => $itemOptions) {
-            if (!isset($itemOptions['url']) && !isset($itemOptions['items'])) {
+            if (!isset($itemOptions['url']) && !isset($itemOptions['items']) && is_array($itemOptions)) {
                 $label = TbArray::popValue('label', $itemOptions, '');
                 $items[$i] = self::menuHeader($label, $itemOptions);
             }

--- a/tests/unit/TbHtmlTest.php
+++ b/tests/unit/TbHtmlTest.php
@@ -2584,6 +2584,7 @@ class TbHtmlTest extends TbTestCase
         $items = array(
             array('label' => 'Header text'),
             array('label' => 'Link', 'url' => '#'),
+            '<li class="divider"></li>'
         );
 
         $html = TbHtml::navList(
@@ -2600,9 +2601,11 @@ class TbHtmlTest extends TbTestCase
             if ($i === 0) {
                 $I->seeNodeCssClass($li, 'nav-header');
                 $I->seeNodeText($li, 'Header text');
-            } else {
+            } elseif($i === 1) {
                 $a = $li->filter('a');
                 $I->seeNodeText($a, $items[$i]['label']);
+            } elseif($i === 2) {
+                $I->seeNodeCssClass($li, 'divider');
             }
         }
     }


### PR DESCRIPTION
Hi. Sorry for my English:)
In the example from http://www.getyiistrap.com/site/components#navs

``` php
<?php echo TbHtml::navList(array(
        array('label' => 'List header'),
        array('label' => 'Home', 'url' => '#', 'active' => true),
        array('label' => 'Library', 'url' => '#'),
        array('label' => 'Applications', 'url' => '#'),
        array('label' => 'Another list header'),
        array('label' => 'Profile', 'url' => '#'),
        array('label' => 'Settings', 'url' => '#'),
        TbHtml::menuDivider(),
        array('label' => 'Help', 'url' => '#'),
    )); ?>
```

Error 

``` php
ErrorException: Argument 2 passed to TbArray::popValue() must be of the type array, string given, called in /home/karneds/www/yiistrap/helpers/TbHtml.php on line 2973 and defined
```
