### PR TITLE
Add default $container for RadioButtonList 

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -909,7 +909,7 @@ class TbHtml extends CHtml // required in order to access the protected methods 
     {
         $inline = TbArray::popValue('inline', $htmlOptions, false);
         $separator = TbArray::popValue('separator', $htmlOptions, ' ');
-        $container = TbArray::popValue('container', $htmlOptions);
+        $container = TbArray::popValue('container', $htmlOptions, 'span');
         $containerOptions = TbArray::popValue('containerOptions', $htmlOptions, array());
         $labelOptions = TbArray::popValue('labelOptions', $htmlOptions, array());
 


### PR DESCRIPTION
Default $container needs to be defined for RadioButtonList for Ajax validation in yiiactivefinder.js to work properly.  This is already defined properly for CheckBoxList and was probably just overlooked for RadioButtonList.
