### PR TITLE
Add enableAjaxValidation and enableClientValidation support

### DIFF
--- a/widgets/TbActiveForm.php
+++ b/widgets/TbActiveForm.php
@@ -700,7 +700,9 @@ class TbActiveForm extends CActiveForm
     {
         $errorOptions = TbArray::popValue('errorOptions', $options, array());
         $errorOptions['type'] = $this->helpType;
-        $error = $this->error($model, $attribute, $errorOptions);
+		$error = $this->error($model, $attribute, $errorOptions, 
+			TbArray::popValue('enableAjaxValidation', $errorOptions, true), 
+			TbArray::popValue('enableClientValidation', $errorOptions, true));
         // kind of a hack for ajax forms but this works for now.
         if (!empty($error) && strpos($error, 'display:none') === false) {
             $options['color'] = TbHtml::INPUT_COLOR_ERROR;


### PR DESCRIPTION
I couldn't set `enableAjaxValidation` and `enableClientValidation` values for the specified field when I used  `TbActiveForm::FieldControlGroup()` methods. I discovered you probably miss these flags calling `TbActiveForm::error()`. 
Usage example: 

``` php
<?php echo $form->checkBoxControlGroup($model, 'rememberMe', array('errorOptions'=>array('enableClientValidation'=>false))); ?>
```
