### PR TITLE
Fixed php warning if html options are used for navlist header item

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -3518,7 +3518,8 @@ EOD;
             }
             if (!isset($itemOptions['url']) && !isset($itemOptions['items'])) {
                 $label = TbArray::popValue('label', $itemOptions, '');
-                $items[$i] = self::menuHeader($label, $itemOptions);
+                $options = TbArray::popValue('htmlOptions', $itemOptions, array());
+                $items[$i] = self::menuHeader($label,  $options);
             }
         }
         return self::nav(self::NAV_TYPE_LIST, $items, $htmlOptions);


### PR DESCRIPTION
This issue also exists in the master branch in the method of the same name.
Should I create a separate pull request for the master branch?
