### PR TITLE
fixed bug in active form widget where help text type always

### DIFF
--- a/widgets/TbActiveForm.php
+++ b/widgets/TbActiveForm.php
@@ -709,7 +709,6 @@ class TbActiveForm extends CActiveForm
             $options['error'] = $error;
         }
         $helpOptions = TbArray::popValue('helpOptions', $options, array());
-        $helpOptions['type'] = $this->helpType;
         $options['helpOptions'] = $helpOptions;
         return $options;
     }


### PR DESCRIPTION
fixed bug in active form widget where help text type always TbHtml::HELP_TYPE_BLOCK
