### PR TITLE
fix navbar collapse issue

### DIFF
--- a/widgets/TbNavbar.php
+++ b/widgets/TbNavbar.php
@@ -98,7 +98,7 @@ class TbNavbar extends CWidget
         $items = ob_get_clean();
         ob_start();
         if ($this->collapse !== false) {
-            TbHtml::addCssClass('nav-collapse', $this->collapseOptions);
+            TbHtml::addCssClass('nav-collapse collapse', $this->collapseOptions);
             ob_start();
             /* @var TbCollapse $collapseWidget */
             $collapseWidget = $this->controller->widget(


### PR DESCRIPTION
When opening the navbar for the first time, the navbar would have a static
height declared. Adding the collapse class to the nav-collapse element
seems to solve this issue.
