### PR TITLE
Update TbNavbar.php > TbCollapse alias error

### DIFF
--- a/widgets/TbNavbar.php
+++ b/widgets/TbNavbar.php
@@ -104,7 +104,7 @@ class TbNavbar extends CWidget
             ob_start();
             /* @var TbCollapse $collapseWidget */
             $collapseWidget = $this->controller->widget(
-                '\TbCollapse',
+                'TbCollapse',
                 array(
                     'toggle' => false, // navbars are collapsed by default
                     'content' => $items,


### PR DESCRIPTION
When we create a TbNavbar with 'collapse" => true we get below error if we do not aplly my update:
"Alias « » is invalid. Make sure it points to an existing directory."

This is due to a wrong "\" before TbCollapse at line 107 in TbCollapse.php

Tested on php 5.4 windows & linux debian
