### PR TITLE
Fix TbHtml.php > alert-danger replace alert-error

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -482,7 +482,7 @@ class TbHtml extends CHtml // required in order to access the protected methods 
     /**
      * @var string the CSS class for displaying error summaries.
      */
-    public static $errorSummaryCss = 'alert alert-block alert-error';
+    public static $errorSummaryCss = 'alert alert-block alert-danger';
     /**
      * @var string the CSS class for displaying error inputs
      */


### PR DESCRIPTION
For bootstrap 3 we should apply alert-danger class instead of alert-error. This will apply correctly the right css red style

tested ok
