### PR TITLE
Assets fix and removed missing css reference

### DIFF
--- a/components/TbApi.php
+++ b/components/TbApi.php
@@ -94,11 +94,12 @@ class TbApi extends CApplicationComponent
      */
     public function registerYiistrapCss($url = null, $media = '')
     {
-        if ($url === null) {
+    	// Obsolete since this file doesn't exist
+        /*if ($url === null) {
             $fileName = YII_DEBUG ? 'yiistrap.css' : 'yiistrap.min.css';
             $url = $this->getAssetsUrl() . '/css/' . $fileName;
         }
-        Yii::app()->getClientScript()->registerCssFile($url, $media);
+        Yii::app()->getClientScript()->registerCssFile($url, $media);*/
     }
 
     /**


### PR DESCRIPTION
Not sure how useful these fixes are since I've only just migrated to using yiistrap (from yii-bootstrap) but had some trouble setting it up using Vagrant.  After following the getting started section on the site, it was still failing to copy the assets across, so was failing to find `bootstrap.css`, etc.  This change creates a fallback for that scenario where it will automatically find the `assets` path in the extension.

I also removed the reference to `yiistrap.css` since it is appears to not exist.
