### PR TITLE
Added support for error displaying in TbHtml activeControlGroup

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -2096,6 +2096,8 @@ EOD;
             $help = self::inputHelp($help, $helpOptions);
         }
         $error = TbArray::popValue('error', $htmlOptions, '');
+        $errorOptions = TbArray::popValue('errorOptions', $htmlOptions, array());
+        $error = self::inputHelp($error, $errorOptions);
 
         $input = isset($htmlOptions['input'])
             ? $htmlOptions['input']


### PR DESCRIPTION
This will allow for errors in $model->$attribute to be automatically displayed by activeControlGroup.
