### PR TITLE
Bs3 fix alert color error

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -216,7 +216,6 @@ class TbHtml extends CHtml // required in order to access the protected methods 
     const ALERT_COLOR_INFO = 'info';
     const ALERT_COLOR_SUCCESS = 'success';
     const ALERT_COLOR_WARNING = 'warning';
-    const ALERT_COLOR_ERROR = 'error';
     const ALERT_COLOR_DANGER = 'danger';
 
     //
@@ -482,7 +481,7 @@ class TbHtml extends CHtml // required in order to access the protected methods 
     /**
      * @var string the CSS class for displaying error summaries.
      */
-    public static $errorSummaryCss = 'alert alert-block alert-error';
+    public static $errorSummaryCss = 'alert alert-block alert-danger';
     /**
      * @var string the CSS class for displaying error inputs
      */

--- a/tests/unit/TbHtmlTest.php
+++ b/tests/unit/TbHtmlTest.php
@@ -2123,7 +2123,7 @@ class TbHtmlTest extends TbTestCase
             )
         );
         $div = $I->createNode($html, 'div.alert');
-        $I->seeNodeCssClass($div, 'alert-block alert-error summary');
+        $I->seeNodeCssClass($div, 'alert-block alert-danger summary');
         $I->seeNodePattern($div, '/^Header text/');
         $I->seeNodePattern($div, '/Footer text$/');
         $li = $div->filter('ul > li')->first();

--- a/widgets/TbAlert.php
+++ b/widgets/TbAlert.php
@@ -53,7 +53,6 @@ class TbAlert extends CWidget
                     TbHtml::ALERT_COLOR_SUCCESS,
                     TbHtml::ALERT_COLOR_WARNING,
                     TbHtml::ALERT_COLOR_INFO,
-                    TbHtml::ALERT_COLOR_ERROR,
                     TbHtml::ALERT_COLOR_DANGER,
                 ); // render all styles by default
             }


### PR DESCRIPTION
Replace alert-error by alert-danger, and remove alert-error (no longer exists in Boostrap 3)
