### PR TITLE
fix php warning when url is null in TbButtonColumn

### DIFF
--- a/widgets/TbButtonColumn.php
+++ b/widgets/TbButtonColumn.php
@@ -64,7 +64,7 @@ class TbButtonColumn extends CButtonColumn
         }
 
         $url = TbArray::popValue('url', $button);
-        if ($url !== '#') {
+        if ($url !== '#' && $url !== null) {
             $url = $this->evaluateExpression($url, array('data' => $data, 'row' => $row));
         }
 


### PR DESCRIPTION
This fixes the bug introduced in #190.
