### PR TITLE
CHG: properly override default activeForm class 

### DIFF
--- a/form/TbForm.php
+++ b/form/TbForm.php
@@ -30,7 +30,7 @@ class TbForm extends CForm
     /**
      * @var array the configuration used to create the active form widget.
      */
-    public $activeForm = array('class' => 'TbActiveForm');
+    public $activeForm = array('class' => '\TbActiveForm');
 
     /**
      * Initializes this form.


### PR DESCRIPTION
Allows supplying activeForm config without specifying form class.

``` php
$form = new TbForm(array(
    'activeForm' => array(
        'enableClientValidation' => true,
    ),
    ...
```
