### PR TITLE
Make TbFormButtonElement adhere to CFormButtonElement specifications

### DIFF
--- a/form/TbFormButtonElement.php
+++ b/form/TbFormButtonElement.php
@@ -13,11 +13,35 @@
 class TbFormButtonElement extends CFormButtonElement
 {
     /**
+     * @var array Core input types (alias=>TbHtml button type)
+     */
+    public static $coreTypes = array(
+        'htmlButton' => TbHtml::BUTTON_TYPE_HTML,
+        'htmlReset' => TbHtml::BUTTON_TYPE_RESET,
+        'htmlSubmit' => TbHtml::BUTTON_TYPE_SUBMIT,
+        'submit' => TbHtml::BUTTON_TYPE_INPUTSUBMIT,
+        'button' => TbHtml::BUTTON_TYPE_INPUTBUTTON,
+        'image' => TbHtml::BUTTON_TYPE_IMAGE,
+        'reset' => TbHtml::BUTTON_TYPE_RESET,
+        'link' => TbHtml::BUTTON_TYPE_LINK,
+        'ajaxLink' => TbHtml::BUTTON_TYPE_AJAXLINK,
+        'ajaxButton' => TbHtml::BUTTON_TYPE_AJAXBUTTON,
+    );
+
+    /**
      * Returns this button.
      * @return string the rendering result.
      */
     public function render()
     {
-        return TbHtml::btn($this->type, $this->label, $this->attributes);
+        $attributes = $this->attributes;
+        $attributes['name'] = $this->name;
+
+        if (isset(self::$coreTypes[$this->type])) {
+            $type = self::$coreTypes[$this->type];
+            return TbHtml::btn($type, $this->label, $attributes);
+        } else {
+			return $this->getParent()->getOwner()->widget($this->type, $attributes, true);
+        }
     }
 }


### PR DESCRIPTION
Make TbFormButtonElement adhere to CFormButtonElement specifications:
- automatically set 'name' property (required for checking if form is submitted)
- use documented core types
- use custom widget if type does not match

http://www.yiiframework.com/doc/api/1.1/CFormButtonElement/
