### PR TITLE
quickfix for the TBModal not using "remote" var

### DIFF
--- a/widgets/TbModal.php
+++ b/widgets/TbModal.php
@@ -155,7 +155,7 @@ class TbModal extends CWidget
      */
     public function initOptions()
     {
-        if ($remote = TbArray::popValue('remote', $this->options)) {
+        if (($remote = $this->remote) || ($remote = TbArray::popValue('remote', $this->options))) {
             $this->options['remote'] = CHtml::normalizeUrl($remote);
         }
 


### PR DESCRIPTION
This fix allows the use of "remote" param when buttonOptions are not provided by the user - real usecase. Issue related #258 

For those who with to not wait, there is a workaround, just set "buttonOptions"=>true, that way you wont see the button and the remote option will be used by the widget.
