### PR TITLE
Drop default pagerCssClass, use the base value

### DIFF
--- a/widgets/TbGridView.php
+++ b/widgets/TbGridView.php
@@ -22,10 +22,6 @@ class TbGridView extends CGridView
      */
     public $type;
     /**
-     * @var string the CSS class name for the pager container. Defaults to 'pagination'.
-     */
-    public $pagerCssClass = 'pagination';
-    /**
      * @var array the configuration for the pager.
      * Defaults to <code>array('class'=>'ext.bootstrap.widgets.TbPager')</code>.
      */


### PR DESCRIPTION
Currently TbGridView::$pagerCssClass defaults to "pagination", which is the same class Yii wraps the actual pager widget in.
