### PR TITLE
Invalid Parameters Exception

### DIFF
--- a/components/TbApi.php
+++ b/components/TbApi.php
@@ -241,7 +241,7 @@ class TbApi extends CApplicationComponent
             } else {
                 if (($path = Yii::getPathOfAlias($this->bootstrapPath)) !== false) {
                     $this->bootstrapPath = $path;
-                } else {
+                } else if ($this->bootstrapPath === false) {
                     throw new Exception("Invalid Bootstrap path and CDN URL not set. Set vendor.twbs.bootstrap.dist alias or cdnUrl parameter in the configuration file.");
                 }
                 $this->_bootstrapUrl = Yii::app()->assetManager->publish($this->bootstrapPath, false, -1, $this->forceCopyAssets);


### PR DESCRIPTION
When vendor.twbs.bootstrap.dist alias and cdnUrl are not set, Yii tries to publish the entire site and gets a PHP Warning.

copy(C:\sv\www\yiistrap-bs3\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\f7a472d9\assets\d7f2a1\jui\css\base\images\ui-bg_flat_0_aaaaaa_40x100.png) [<a href='function.copy'>function.copy</a>]: failed to open stream: Invalid argument

I think Yiistrap should throw an Exception, allowing to realize what's wrong and prevent Yii from copying the whole site into assets.
