### PR TITLE
Fixed TbTabs for more than one dropdown Tab

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -3222,7 +3222,7 @@ EOD;
      * @param integer $i the running index.
      * @return array the items.
      */
-    protected static function normalizeTabs($tabs, &$panes, $i = 0)
+    protected static function normalizeTabs($tabs, &$panes, &$i = 0)
     {
         $menuItems = array();
         foreach ($tabs as $tabOptions) {


### PR DESCRIPTION
When creating a TbTabs Widget with more than one Dropdown tab, each subentry will poit to the same page.

This commit fixes this.

PS: I hope I did this right, this is my first contribution to a foreign project :)
