### PR TITLE
Pass iconOptions in TbHtml::menu() to icon() function

### DIFF
--- a/widgets/TbGridView.php
+++ b/widgets/TbGridView.php
@@ -22,10 +22,6 @@ class TbGridView extends CGridView
      */
     public $type;
     /**
-     * @var string the CSS class name for the pager container. Defaults to 'pagination'.
-     */
-    public $pagerCssClass = 'pagination';
-    /**
      * @var array the configuration for the pager.
      * Defaults to <code>array('class'=>'ext.bootstrap.widgets.TbPager')</code>.
      */


### PR DESCRIPTION
As stated in the title, the iconOptions are not passed to the icon() function in the menu function of TbHtml. Yet this is required for setting icon colors of navBars.

The following change in the menu() function :

```
            //added $options parameter in icon() call to allow for icon coloration
            if (!empty($icon)) {
                $label = self::icon($icon,$options) . ' ' . $label;
            }
```

Not sure whether i chose the right branches for my pull request though.

Thanks for the awesome work guys.
