### PR TITLE
Ignore bootstrap 3.3.x in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "twbs/bootstrap": ">=3.0.0"
+        "twbs/bootstrap": "3.2.*"
     },
     "require-dev": {
         "codeception/codeception": "@stable",


### PR DESCRIPTION
Bootstrap 3.3.x requires jquery 1.9.1 or higher
